### PR TITLE
creator have to be 0 to avoid status code 500 while trying to install pa...

### DIFF
--- a/context/credentials.json.tpl
+++ b/context/credentials.json.tpl
@@ -7,7 +7,7 @@
          "comment": "",
          "created": "2014-12-29T16:48:50Z",
          "deactivated": null,
-         "creator": 1,
+         "creator": 0,
          "secret_key": "${secret_key}"
       }
    }


### PR DESCRIPTION
Hi Corentin,

I had issues when I tried to install packages from a docker-localshop with preconfigured credentials via the environment variables. From the pip.log I learnd that the server was returning a status code of 500. So I investigated the container and noticed that the preconfigured credentials have a creator_id of 1 in the database, whereas the ones created via the admin interface have a creator_id of 0.

So I made a fork and sat the creator to 0 int the tempate for the credentials fixture.

After that the preconfigured keys are working.

So I think this change is useful for others who want to launch a docker-localshop container with predictable credatials.

- Cornelius